### PR TITLE
Add means of including/excluding Munki items based on the pkginfo `name`

### DIFF
--- a/munki-promoter.py
+++ b/munki-promoter.py
@@ -524,7 +524,7 @@ def prep_set_edit_date(munki_path, config, overwrite=False, promotion=None, prom
 			promotions = config["promotions"]
 			if does_promotion_exist(promotion, promotions):
 				_, promote_from, _, custom_items = get_promotion_info(promotion, promotions, config, config_path)
-				return prep_pkgsinfo_edit_date(munki_path, promote_from=promote_from, promote_from_days=promote_from_days, custom_items=custom_items) 
+				return prep_pkgsinfo_edit_date(munki_path, config, promote_from=promote_from, promote_from_days=promote_from_days, custom_items=custom_items) 
 			else:
 				# error: catalog does not exist
 				logging.error(f'Promotion "{promotion}" not found! Use --list to see valid catalogs to promote. Promotions can be configured in {config_path}.')

--- a/munki-promoter.py
+++ b/munki-promoter.py
@@ -214,7 +214,7 @@ def check_selection_specified_correctly(config, config_path):
 				logging.error(f'Selection type set incorrectly in {config_path}. Selection type must be "inclusion", "exclusion", or "all", but was set to {config["selection"]["type"]}.')
 				sys.exit(1)
 		else:
-			logging.warning(f"Selection key found in {config_path}, but no selection type found. All items files will be considered.")
+			logging.warning(f"Selection key found in {config_path}, but no selection type found. All items will be considered.")
 
 # ----------------------------------------
 # 					Slack


### PR DESCRIPTION
Adds the `selection` top-level key. This allows you to define inclusions and exclusions on the basis of the pkginfo `name`, so that you can run `munki-promoter` only on a subset of your repo items.

Implements #8.