### PR TITLE
Validate Slack webhook URL, fix minor undefined variable issue

### DIFF
--- a/munki-promoter.py
+++ b/munki-promoter.py
@@ -392,7 +392,7 @@ def prep_single_promotion(promotion, config, munki_path, config_path):
 		promotions = config["promotions"]
 		if does_promotion_exist(promotion, promotions):
 			promote_to, promote_from, days, custom_items = get_promotion_info(promotion, promotions, config, config_path)
-			names, version, custom_item_descriptions, promotions = prep_pkgsinfo_single_promotion(promote_to, promote_from, days, custom_items, munki_path) 
+			names, version, custom_item_descriptions, promotions = prep_pkgsinfo_single_promotion(promote_to, promote_from, days, custom_items, munki_path, config)
 			return names, version, custom_item_descriptions, promotions, promote_to
 		else:
 			# error: catalog does not exist
@@ -403,7 +403,7 @@ def prep_single_promotion(promotion, config, munki_path, config_path):
 		logging.error(f'No promotions are currently defined in {config_path}.')
 		sys.exit(1)
 
-def prep_pkgsinfo_single_promotion(promote_to, promote_from, days, custom_items, munki_path):
+def prep_pkgsinfo_single_promotion(promote_to, promote_from, days, custom_items, munki_path, config):
 	names = []
 	versions = []
 	promotions = []


### PR DESCRIPTION
This pull request includes a change that ensures Slack webhook URLs are using the HTTPS scheme, to avoid potential issues with file:// or other URLs, as suggested [here](https://bandit.readthedocs.io/en/latest/blacklists/blacklist_calls.html#b310-urllib-urlopen).

Also fixes a bug where `config` is unassigned in a function that needs it.