### PR TITLE
Support wildcard patterns in custom_items

### DIFF
--- a/munki-promoter.py
+++ b/munki-promoter.py
@@ -5,6 +5,7 @@
 # adapted from a script by Arjen van Bochoven (https://github.com/bochoven)
 
 import datetime
+import fnmatch
 import plistlib
 import logging
 import os
@@ -457,15 +458,25 @@ def prep_item_for_promotion(item, promote_to, promote_from, days, custom_items, 
 	except Exception as e:
 		logging.error(f"File {item_path} is missing expected keys.", exc_info=True)
 		sys.exit(1)
-	# check if custom item
+	# check if custom item: exact match first, then glob/wildcard patterns
+	# (first match wins; patterns are matched case-sensitively via fnmatchcase)
+	custom = None
 	if item_name in custom_items and type(custom_items[item_name]) == dict:
-		if "days_in_catalog" in custom_items[item_name]:
-			days = custom_items[item_name]["days_in_catalog"]
-		if "promote_to" in custom_items[item_name] and type(custom_items[item_name]["promote_to"]) == list and len(custom_items[item_name]["promote_to"]) > 0:
-			promote_to = custom_items[item_name]["promote_to"]
+		custom = custom_items[item_name]
+	else:
+		for pattern, opts in custom_items.items():
+			if '*' in pattern or '?' in pattern or '[' in pattern:
+				if fnmatch.fnmatchcase(item_name, pattern) and type(opts) == dict:
+					custom = opts
+					break
+	if custom:
+		if "days_in_catalog" in custom:
+			days = custom["days_in_catalog"]
+		if "promote_to" in custom and type(custom["promote_to"]) == list and len(custom["promote_to"]) > 0:
+			promote_to = custom["promote_to"]
 			changed_promote_to = True
-		if "promote_from" in custom_items[item_name] and type(custom_items[item_name]["promote_from"]) == list and len(custom_items[item_name]["promote_from"]) > 0:
-			promote_from = custom_items[item_name]["promote_from"]
+		if "promote_from" in custom and type(custom["promote_from"]) == list and len(custom["promote_from"]) > 0:
+			promote_from = custom["promote_from"]
 	# check if eligable for promotion based on current catalogs
 	if set(item_catalogs) == set(promote_from): # convert to set so order doesn't matter
 		# check if eligable for promotion based on days
@@ -585,10 +596,19 @@ def prep_item_edit_date(item, item_path, overwrite, promote_from, promote_from_d
 	except Exception as e:
 		logging.error(f"File {item_path} is missing expected keys.", exc_info=True)
 		sys.exit(1)
-	# if for a specific promotion, check if custom item
-	if promote_from and (item_name in custom_items and type(custom_items[item_name]) == dict):
-		if "promote_from" in custom_items[item_name] and type(custom_items[item_name]["promote_from"]) == list and len(custom_items[item_name]["promote_from"]) > 0:
-			promote_from = custom_items[item_name]["promote_from"]
+	# if for a specific promotion, check if custom item (exact then glob)
+	if promote_from:
+		custom = None
+		if item_name in custom_items and type(custom_items[item_name]) == dict:
+			custom = custom_items[item_name]
+		else:
+			for pattern, opts in custom_items.items():
+				if '*' in pattern or '?' in pattern or '[' in pattern:
+					if fnmatch.fnmatchcase(item_name, pattern) and type(opts) == dict:
+						custom = opts
+						break
+		if custom and "promote_from" in custom and type(custom["promote_from"]) == list and len(custom["promote_from"]) > 0:
+			promote_from = custom["promote_from"]
 	# check if overwriting or if value missing
 	if not "_metadata" in item:
 		item["_metadata"] = dict()


### PR DESCRIPTION
### Summary
- `custom_items` keys can now be shell-glob patterns (`*`, `?`, `[...]`) matched against each pkginfo's `name` via `fnmatch.fnmatchcase`.
- Exact matches still win over patterns (existing behaviour); only keys containing a glob metacharacter are treated as patterns, so configs with literal names are unaffected.

### Why
`custom_items` today requires an exact `name` match, which doesn't fit any Munki item whose `name` changes between versions — installers with a version suffix, OS-release pkgs, daily builds, vendor channels. Every new release forces a config edit to copy the same rule under a new key, and missing one means the item silently falls through to the default promotion.

A wildcard pattern collapses a whole family of versioned items into one declarative rule that keeps working as new versions land:

```yaml
custom_items:
  "macOS-*":          # matches macOS-14.5, macOS-14.6, macOS-Sequoia, …
    days_in_catalog: 3
  "Adobe*-2025":      # matches AdobePhotoshop-2025, AdobeIllustrator-2025, …
    days_in_catalog: 14
  "FirefoxESR-*":     # matches FirefoxESR-115.8, FirefoxESR-128.0, …
    promote_to: ["production"]
```

Exact keys still win over patterns, so a narrow override for a specific version can coexist with the family rule.

### What changed
```yaml
# Before — one entry per version
custom_items:
  macOS-14.5:
    days_in_catalog: 3
  macOS-14.6:
    days_in_catalog: 3

# After — one pattern
custom_items:
  "macOS-*":
    days_in_catalog: 3
```

Implementation:
- `import fnmatch` added.
- `prep_item_for_promotion` and `prep_item_edit_date` both lookup exact match first, then iterate pattern keys and take the first `fnmatch.fnmatchcase` hit. Only keys containing `*`, `?`, or `[` are candidates for pattern matching.
- Matching is case-sensitive to stay consistent with Munki's own `name` handling.

### Compatibility / risk
- Existing configs with literal keys: no change — exact match path wins.
- **Plist and YAML pkgsinfo both supported.** The pattern match runs against `item["name"]` in the already-loaded pkginfo dict, so it's agnostic to whichever format produced the dict. This PR is independent of the separate YAML-support PR and works on an unmodified (plist-only) upstream.
- First-match ordering: iteration follows dict insertion order (Python ≥ 3.7), so users with overlapping patterns get predictable "first match wins" semantics.
- A user whose existing literal key happens to contain `*`, `?`, or `[` would now have it treated as a pattern. I expect this is vanishingly rare for Munki `name` values, but it's worth noting.

### Test plan
- [ ] Plist pkgsinfo with wildcard `custom_items` key: match works, options applied
- [ ] Config with exact-match key: behaves as before
- [ ] Config with single wildcard pattern matching multiple items: all matched items use the pattern's options
- [ ] Config with both exact and pattern that would both match: exact wins
- [ ] Config with two patterns that would both match: first declared wins
- [ ] Config with no wildcard metacharacters: `fnmatch` path never runs (quick sanity)