### PR TITLE
Skip pkginfo without catalogs instead of exiting

### DIFF
--- a/munki-promoter.py
+++ b/munki-promoter.py
@@ -450,13 +450,19 @@ def prep_pkgsinfo_single_promotion(promote_to, promote_from, days, custom_items,
 
 def prep_item_for_promotion(item, promote_to, promote_from, days, custom_items, item_path):
 	changed_promote_to = False
-	try:		
+	try:
 		item_name = item["name"]
 		item_version = item["version"]
-		item_catalogs = item["catalogs"]
-	except Exception as e:
-		logging.error(f"File {item_path} is missing expected keys.", exc_info=True)
+	except KeyError as e:
+		logging.error(f"File {item_path} is missing required key {e}.", exc_info=True)
 		sys.exit(1)
+	# `catalogs` is optional in pkginfo. An item with no catalogs isn't in
+	# any catalog, so it can't be promoted — skip with a warning rather than
+	# exiting.
+	item_catalogs = item.get("catalogs")
+	if not item_catalogs:
+		logging.warning(f"File {item_path} has no 'catalogs' set — skipping (not eligible for any promotion).")
+		return None, None, None, None
 	# check if custom item
 	if item_name in custom_items and type(custom_items[item_name]) == dict:
 		if "days_in_catalog" in custom_items[item_name]:
@@ -580,11 +586,15 @@ def prep_pkgsinfo_edit_date(munki_path, config, overwrite=False, promote_from=No
 def prep_item_edit_date(item, item_path, overwrite, promote_from, promote_from_days, custom_items):
 	try:
 		item_name = item["name"]
-		if promote_from:
-			item_catalogs = item["catalogs"]
-	except Exception as e:
-		logging.error(f"File {item_path} is missing expected keys.", exc_info=True)
+	except KeyError as e:
+		logging.error(f"File {item_path} is missing required key {e}.", exc_info=True)
 		sys.exit(1)
+	if promote_from:
+		# `catalogs` is optional; skip with warning when missing or empty.
+		item_catalogs = item.get("catalogs")
+		if not item_catalogs:
+			logging.warning(f"File {item_path} has no 'catalogs' set — skipping (not eligible for any promotion).")
+			return None, None
 	# if for a specific promotion, check if custom item
 	if promote_from and (item_name in custom_items and type(custom_items[item_name]) == dict):
 		if "promote_from" in custom_items[item_name] and type(custom_items[item_name]["promote_from"]) == list and len(custom_items[item_name]["promote_from"]) > 0:


### PR DESCRIPTION
Closes #17.

### Summary
- A pkginfo missing the `catalogs` key no longer takes down the whole promotion run.
- Instead, `munki-promoter` logs a `WARNING` naming the file and moves on. The rest of the run continues normally.
- `name` and `version` remain required — those are genuinely malformed pkginfo and still exit.

### Why
Reported by you in #17: items generated by [`munki-mscp-generator`](https://github.com/jc0b/munki-mscp-generator) leave `catalogs` unset by default. A single such file in the repo triggers the generic `except Exception` at the top of `prep_item_for_promotion` and calls `sys.exit(1)`, killing every unrelated promotion.

The design question in the issue was "not sure if this is the behaviour we want." The behaviour in this PR:
- **Skip**, because an item with no catalogs isn't in any catalog, so by definition it can't be promoted from one.
- **Warn at `WARNING` level**, because the pkginfo exists in the repo and the admin probably wants to know it's being ignored (rather than silently skipping at `DEBUG`).

This keeps accidentally-blank `catalogs` entries visible without being fatal, and lets tooling that legitimately ships without `catalogs` (mscp-generator, scaffolding scripts) coexist with promotion runs.

### What changed
- `prep_item_for_promotion`: split the required-keys try/except (`name`, `version` → exit on miss) from the optional-keys lookup (`catalogs` → skip with warning on miss/empty).
- `prep_item_edit_date`: same pattern. `catalogs` is only read when `promote_from` is set; when it is set and missing, skip with warning.
- Exception narrowed from bare `Exception` to `KeyError` in both sites so that any unrelated bug in the same `try` block surfaces as a real traceback, not a generic "missing expected keys" message.

### Compatibility / risk
- Well-formed pkginfo (name + version + catalogs): unchanged code path.
- Pkginfo missing `name` or `version`: still exits with the same error (now more specifically names the missing key, thanks to `KeyError as e`).
- Pkginfo missing `catalogs`: previously aborted the run; now logs at WARNING and is skipped.
- Pkginfo with empty `catalogs: []`: treated the same as missing — skipped with warning. This is a small behaviour change from "technically valid, probably never matches any `promote_from` so silently skipped" to "explicitly warned". Arguably more helpful.

### Test plan
- [ ] Repo with one pkginfo missing `catalogs` key: WARNING logged, other items still promote
- [ ] Repo with one pkginfo with `catalogs: []`: WARNING logged, other items still promote
- [ ] Repo with one pkginfo missing `name`: still exits with clear error (`missing required key 'name'`)
- [ ] Well-formed repo: no new warnings, behaviour unchanged
- [ ] `--reset-edit-date` / `--set-unknown-edit-date` flows: same behaviour on items missing `catalogs` when a promotion is specified